### PR TITLE
fixed sessions today

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,9 @@ class ApplicationController < ActionController::Base
   private
 
   def set_sessions_count_today
-    @sessions_count_today = Session.where("DATE(start_time) = ?", Date.current).count
+    now = Time.current
+    end_of_day = now.end_of_day
+    @sessions_count_today = Session.where("start_time >= ? AND end_time <= ?", now, end_of_day).count
   end
 
 end


### PR DESCRIPTION
- The sessions today in the navbar now reflects how many sessions are available, after the current time. Rather than all sessions today